### PR TITLE
Removed redundant sha512 sum checks (for mongoose.c/.h and strscan.c/.h)

### DIFF
--- a/archpackage/PKGBUILD
+++ b/archpackage/PKGBUILD
@@ -12,8 +12,6 @@ license=('GPL3')
 depends=('openssl' 'gcc' 'curl')
 makedepends=('cmake' 'git' 'gcc' 'make' 'openssl' 'curl')
 
-mongoose_pkgver="7.12"
-
 _srcprefix="file://$(pwd)"
 _libfiles=(
   "main.cpp"
@@ -26,6 +24,10 @@ _libfiles=(
   "settings.h"
   "users.cpp"
   "users.h"
+  "mongoose.c"
+  "mongoose.h"
+  "strscan.c"
+  "strscan.h"
 )
 
 _rcfiles=(
@@ -76,18 +78,6 @@ source=(${source[@]} "$_srcprefix/resources/CascadiaMono.woff")
 _rcfiles=(${_rcfiles[@]} "CascadiaMono.woff")
 sha512sums=(${sha512sums[@]} "180d3248b16d5d3ed3aca598eb67e7edb8ec8553c21edafe96d9d268989c0d7896a615c7e67527d1fca913308e1b24a363a59c7826b7e341012e853736db4fa6")
 
-
-external=(${external[@]} "https://raw.githubusercontent.com/cesanta/mongoose/$mongoose_pkgver/mongoose.c")
-sha512sums=(${sha512sums[@]} "344192988525bca828254e50ad06ab5f31abc55fe40088787e49480e26276fc6ae675d729477ab382ab63d55c1af114e590408add4ed98738c43490810b7d5f0")
-
-external=(${external[@]} "https://raw.githubusercontent.com/cesanta/mongoose/$mongoose_pkgver/mongoose.h")
-sha512sums=(${sha512sums[@]} "bdba75930f6cde1a005102ef8add3a99ab1d208b87c112ade69537d09f73e5c933777891168d509e3d9d142ee03c9d277933adc12293edba2ef02a0573ec5ec6")
-
-external=(${external[@]} "https://raw.githubusercontent.com/imperzer0/strscan/6dab57b46952171286cffd3f4e15c0a7f1b8704d/strscan.c")
-sha512sums=(${sha512sums[@]} "3c342a5706e6a0fcc54493343646dc5e97a9f19ff34c95c1f829791592e1f94132bfd0155f49447219c4b20042f00d1ff64f9ff83256eb819b8c023f1e224527")
-
-external=(${external[@]} "https://raw.githubusercontent.com/imperzer0/strscan/6dab57b46952171286cffd3f4e15c0a7f1b8704d/strscan.h")
-sha512sums=(${sha512sums[@]} "235b69b020345d492193eb409df41b57ed6a2c82aa3598755a6b00f411e2f7a7a3f1a0ba6dccaec22a5f0b2dd230157d61e7fd008e0ca3eddfc318fb8c4d3a06")
 
 source=(${source[@]} ${external[@]})
 


### PR DESCRIPTION
It was causing errors in github workflow and is just a headache to keep track of